### PR TITLE
Add feature to remove background

### DIFF
--- a/ndjsontosvg/ndjsontosvg.py
+++ b/ndjsontosvg/ndjsontosvg.py
@@ -111,8 +111,9 @@ def ndjsontosvg(filein, numberofsamples, outsize=256,
         with open(outfilename, 'w') as f_out:
             drawing = item.get('drawing')
             _write_header(f_out, outsize, item.get('key_id'))
-            f_out.write('\t<rect width="100%" height="100%" ')
-            f_out.write('fill="{:s}" />\n'.format(backgroundcolour))
+            if backgroundcolour != "none":
+                f_out.write('\t<rect width="100%" height="100%" ')
+                f_out.write('fill="{:s}" />\n'.format(backgroundcolour))
             for line in drawing:
                 _draw_line(f_out, line, linecolour, scale)
             f_out.write('</svg>')

--- a/ndjsontosvg/ui/ndjsontosvg_command_line.py
+++ b/ndjsontosvg/ui/ndjsontosvg_command_line.py
@@ -35,7 +35,8 @@ def main(args=None):
 
     parser.add_argument("-bc", "--backgroundcolour",
                         default="white",
-                        help="The background colour to use."
+                        help="The background colour to use. A value of " + \
+                            " 'none' will remove the background."
                         )
 
     parser.add_argument("-o", "--outdir",
@@ -51,7 +52,7 @@ def main(args=None):
 
     parser.add_argument("-rs", "--randomsort",
                         action="store_true",
-                        help="Make a random selection, rather than the" + \
+                        help="Make a random selection, rather than the " + \
                             "first n lines",
                         )
 


### PR DESCRIPTION
Closes Issue #1

If the user specifies the backgroundcolour color as "none", then generate the document without adding a background rectangle. This allows the SVG outputs to be used in applications that either require a transparent background or where the rectangle itself will be printed, e.g., on pen plotters and laser cutters.

Also fix a typo in UI help.